### PR TITLE
Fix JWT Token Variable for GCP Cloud Function Header Compatibility

### DIFF
--- a/modules/module-1/resources/cloud_function/data/main.py
+++ b/modules/module-1/resources/cloud_function/data/main.py
@@ -59,7 +59,7 @@ def generate_auth(userInfo):
 
 def auth_is_valid(req):
     JWT_SECRET = ''
-    JWT_TOKEN = req.headers.get('JWT_TOKEN') or req.headers.get('jwt_token')
+    JWT_TOKEN = req.headers.get('JWT-TOKEN') or req.headers.get('jwt-token')
     if JWT_TOKEN != '':
         JWT_SECRET = os.environ['JWT_SECRET']
         try:

--- a/modules/module-1/src/src/common/httpService.js
+++ b/modules/module-1/src/src/common/httpService.js
@@ -5,6 +5,6 @@ export default axios.create({
   baseURL: "CLOUD_FUNCTION_URL",
   headers: {
     "Content-type": "application/json",
-    "JWT_TOKEN": getToken(),
+    "jwt-token": getToken(),
   }
 });


### PR DESCRIPTION
Updated the JWT token variable to remove underscores, ensuring compatibility with Google Cloud Functions, which does not recognize headers with underscores. Verified that the new header configuration is correctly processed by GCP Cloud Functions.

Changes:

- Renamed JWT token header variable to remove underscores.
